### PR TITLE
[#1881] Cache annotated method lists already in a sorted state.

### DIFF
--- a/framework/src/play/mvc/ActionInvoker.java
+++ b/framework/src/play/mvc/ActionInvoker.java
@@ -178,14 +178,6 @@ public class ActionInvoker {
                             // @Catch
                             Object[] args = new Object[]{ex.getTargetException()};
                             List<Method> catches = Java.findAllAnnotatedMethods(Controller.getControllerClass(), Catch.class);
-                            Collections.sort(catches, new Comparator<Method>() {
-
-                                public int compare(Method m1, Method m2) {
-                                    Catch catch1 = m1.getAnnotation(Catch.class);
-                                    Catch catch2 = m2.getAnnotation(Catch.class);
-                                    return catch1.priority() - catch2.priority();
-                                }
-                            });
                             ControllerInstrumentation.stopActionCall();
                             for (Method mCatch : catches) {
                                 Class[] exceptions = mCatch.getAnnotation(Catch.class).value();
@@ -290,14 +282,6 @@ public class ActionInvoker {
 
     private static void handleBefores(Http.Request request) throws Exception {
         List<Method> befores = Java.findAllAnnotatedMethods(Controller.getControllerClass(), Before.class);
-        Collections.sort(befores, new Comparator<Method>() {
-
-            public int compare(Method m1, Method m2) {
-                Before before1 = m1.getAnnotation(Before.class);
-                Before before2 = m2.getAnnotation(Before.class);
-                return before1.priority() - before2.priority();
-            }
-        });
         ControllerInstrumentation.stopActionCall();
         for (Method before : befores) {
             String[] unless = before.getAnnotation(Before.class).unless();
@@ -332,14 +316,6 @@ public class ActionInvoker {
 
     private static void handleAfters(Http.Request request) throws Exception {
         List<Method> afters = Java.findAllAnnotatedMethods(Controller.getControllerClass(), After.class);
-        Collections.sort(afters, new Comparator<Method>() {
-
-            public int compare(Method m1, Method m2) {
-                After after1 = m1.getAnnotation(After.class);
-                After after2 = m2.getAnnotation(After.class);
-                return after1.priority() - after2.priority();
-            }
-        });
         ControllerInstrumentation.stopActionCall();
         for (Method after : afters) {
             String[] unless = after.getAnnotation(After.class).unless();
@@ -388,14 +364,6 @@ public class ActionInvoker {
 
         try {
             List<Method> allFinally = Java.findAllAnnotatedMethods(Controller.getControllerClass(), Finally.class);
-            Collections.sort(allFinally, new Comparator<Method>() {
-
-                public int compare(Method m1, Method m2) {
-                    Finally finally1 = m1.getAnnotation(Finally.class);
-                    Finally finally2 = m2.getAnnotation(Finally.class);
-                    return finally1.priority() - finally2.priority();
-                }
-            });
             ControllerInstrumentation.stopActionCall();
             for (Method aFinally : allFinally) {
                 String[] unless = aFinally.getAnnotation(Finally.class).unless();

--- a/framework/src/play/utils/Java.java
+++ b/framework/src/play/utils/Java.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,8 @@ import play.mvc.After;
 import play.mvc.Before;
 import play.mvc.Finally;
 import play.mvc.With;
+import static java.util.Collections.addAll;
+import static java.util.Collections.sort;
 
 /**
  * Java utils
@@ -273,7 +276,6 @@ public class Java {
      * @return A list of method object
      */
     public static List<Method> findAllAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType) {
-
         return getJavaWithCaching().findAllAnnotatedMethods(clazz, annotationType);
     }
 
@@ -475,7 +477,7 @@ class JavaWithCaching {
      * @param annotationType The annotation class
      * @return A list of method object
      */
-    public List<Method> findAllAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType) {
+    public List<Method> findAllAnnotatedMethods(Class<?> clazz, final Class<? extends Annotation> annotationType) {
 
         if( clazz == null ) {
             return new ArrayList<Method>(0);
@@ -494,6 +496,7 @@ class JavaWithCaching {
             }
             // have to resolve it.
             methods = new ArrayList<Method>();
+
             // get list of all annotated methods on this class..
             for( Method method : findAllAnnotatedMethods( clazz)) {
                 if (method.isAnnotationPresent(annotationType)) {
@@ -501,10 +504,34 @@ class JavaWithCaching {
                 }
             }
 
+            sortByPriority(methods, annotationType);
+
             // store it in cache
             classAndAnnotation2Methods.put( key, methods);
 
             return methods;
+        }
+    }
+
+    private void sortByPriority(List<Method> methods, final Class<? extends Annotation> annotationType) {
+        try {
+            final Method priority = annotationType.getMethod("priority");
+            sort(methods, new Comparator<Method>() {
+                @Override public int compare(Method m1, Method m2) {
+                    try {
+                        Integer priority1 = (Integer) priority.invoke(m1.getAnnotation(annotationType));
+                        Integer priority2 = (Integer) priority.invoke(m2.getAnnotation(annotationType));
+                        return priority1.compareTo(priority2);
+                    }
+                    catch (Exception e) {
+                        // should not happen
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+        catch (NoSuchMethodException e) {
+            // no need to sort - this annotation doesn't have priority() method
         }
     }
 


### PR DESCRIPTION
This prevents concurrent resorting of cached lists in multiple request threads, which sometimes results in ConcurrentModificationException, especially under Java 8.