### PR TITLE
exc-handling-increaseCookieLogging

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -661,7 +661,13 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
         Map<String, Http.Cookie> cookies = new HashMap<String, Http.Cookie>(16);
         String value = nettyRequest.headers().get(COOKIE);
         if (value != null) {
-            Set<Cookie> cookieSet =  ServerCookieDecoder.STRICT.decode(value);
+            Set<Cookie> cookieSet = null;
+            try{
+                ServerCookieDecoder.STRICT.decode(value);
+            }catch(IllegalArgumentException e){
+                // Attempt to continue without cookies.
+                Logger.warn(e, "Failed deconding cookies from %s", value);
+            }
             if (cookieSet != null) {
                 for (Cookie cookie : cookieSet) {
                     Http.Cookie playCookie = new Http.Cookie();

--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -666,7 +666,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                 ServerCookieDecoder.STRICT.decode(value);
             }catch(IllegalArgumentException e){
                 // Attempt to continue without cookies.
-                Logger.warn(e, "Failed deconding cookies from %s", value);
+                Logger.warn(e, "Failed decoding cookies from %s", value);
             }
             if (cookieSet != null) {
                 for (Cookie cookie : cookieSet) {


### PR DESCRIPTION
for when the cookie decoding fails. This should allow us to understand better why it is happening and then implement a more permanent fix. Attempts to continue without cookies, in the general case, this might not work well.