### PR TITLE
HEALTH-198 Escape the localized message parameter values

### DIFF
--- a/framework/src/play/templates/GroovyTemplate.java
+++ b/framework/src/play/templates/GroovyTemplate.java
@@ -494,7 +494,7 @@ public class GroovyTemplate extends BaseTemplate {
                 // extract args from val
                 Object[] args = new Object[val.length - 1];
                 for (int i = 1; i < val.length; i++) {
-                    args[i - 1] = val[i];
+                    args[i - 1] = __safeFaster(val[i]);
                 }
                 return Messages.get(val[0], args);
             }


### PR DESCRIPTION
# Motivation

As stated in HEALTH-198, there's a XSS found in production, which basically executes as follows. 
Having a localized message tag with parameters in the html template, e.g. 
```
localized.message.key = This is a message parameterized with %s
param = "<script>alert(document.domain)</script>"
```
```
&{'localized.message.key', param}
```
would cause `param` to go unescaped into the result string and be injected into the HTML page. 

# Solution
The most general solution is to force message parameters be escaped in `GroovyTemplate.ExecutableTemplate.__getMessage()`. 

