### PR TITLE
ADS-2883 Enable default profile in validation plugin

### DIFF
--- a/framework/src/play/data/validation/ValidationPlugin.java
+++ b/framework/src/play/data/validation/ValidationPlugin.java
@@ -122,7 +122,7 @@ public class ValidationPlugin extends PlayPlugin {
                 }
             }
             Object[] rArgs = ActionInvoker.getActionMethodArgs(actionMethod, instance);
-            ValidationCycle validationCycle = new ValidationCycle(new String[0]);
+            ValidationCycle validationCycle = new ValidationCycle(new String[]{"default"});
             validateMethodParameters(null, actionMethod, rArgs, validationCycle);
             validateMethodPre(null, actionMethod, rArgs, validationCycle);
             return validationCycle.violations;


### PR DESCRIPTION
https://nostosolutions.atlassian.net/browse/ADS-2883

When I upgraded the `ValidationPlugin` to work with Oval 3.0 (#39), I initialised `ValidationCycle` with no active profiles. This causes Oval to skip validation. I looked through the Oval code and figured out that I need to use the `"default"` profile to activate validation by default.

I tested this change in my local playcart environment and it works.