### PR TITLE
Lower logging levels on servlets to trace for 404 responses and debug…

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group 'com.nosto.play'
-version '1.8.0-nosto-GA-7'
+version '1.8.0-nosto-GA-8'
 
 java {
     withSourcesJar()

--- a/framework/test-src/play/server/JakartaServletWrapperTest.java
+++ b/framework/test-src/play/server/JakartaServletWrapperTest.java
@@ -1,0 +1,319 @@
+package play.server;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import java.lang.reflect.Method;
+import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for the JakartaServletWrapper class
+ */
+public class JakartaServletWrapperTest {
+
+    private JakartaServletWrapper wrapper;
+    private Method isClientDisconnectMethod;
+
+    @Before
+    public void setUp() throws Exception {
+        // Create an instance of JakartaServletWrapper
+        wrapper = new JakartaServletWrapper();
+
+        // Get access to the private isClientDisconnect method using reflection
+        isClientDisconnectMethod = JakartaServletWrapper.class.getDeclaredMethod("isClientDisconnect", Throwable.class);
+        isClientDisconnectMethod.setAccessible(true);
+    }
+
+    /**
+     * Helper method to invoke the private isClientDisconnect method
+     */
+    private boolean invokeIsClientDisconnect(Throwable t) throws Exception {
+        return (boolean) isClientDisconnectMethod.invoke(wrapper, t);
+    }
+
+    /**
+     * Test that ClosedChannelException is correctly identified as a client disconnect
+     */
+    @Test
+    public void testClosedChannelException() throws Exception {
+        assertTrue(invokeIsClientDisconnect(new ClosedChannelException()));
+    }
+
+    /**
+     * Test that exceptions with class names containing specific patterns are identified as client disconnects
+     */
+    @Test
+    public void testClassNamePatterns() throws Exception {
+        // Test ClientAbortException
+        Exception clientAbortException = new MockClientAbortException();
+        assertTrue(invokeIsClientDisconnect(clientAbortException));
+
+        // Test EofException
+        Exception eofException = new MockEofException();
+        assertTrue(invokeIsClientDisconnect(eofException));
+
+        // Test ConnectionClosedException
+        Exception connectionClosedException = new MockConnectionClosedException();
+        assertTrue(invokeIsClientDisconnect(connectionClosedException));
+    }
+
+    /**
+     * Test that exceptions with messages containing specific patterns are identified as client disconnects
+     */
+    @Test
+    public void testMessagePatterns() throws Exception {
+        // Test various message patterns
+        assertTrue(invokeIsClientDisconnect(new Exception("Connection reset by peer")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Connection reset")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Software caused connection abort")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Premature EOF")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Stream closed")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Socket closed")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Reset by peer")));
+        assertTrue(invokeIsClientDisconnect(new Exception("Connection aborted")));
+    }
+
+    /**
+     * Test that nested exceptions (cause chain) are correctly identified
+     */
+    @Test
+    public void testNestedExceptions() throws Exception {
+        // Create a nested exception with a client disconnect cause
+        Exception rootCause = new ClosedChannelException();
+        Exception middleCause = new Exception("Some middle exception", rootCause);
+        Exception topException = new Exception("Top level exception", middleCause);
+
+        assertTrue(invokeIsClientDisconnect(topException));
+    }
+
+    /**
+     * Test that circular references in exception chains are handled correctly
+     */
+    @Test
+    public void testCircularExceptionReferences() throws Exception {
+        // Create exceptions with circular references
+        Exception exception1 = new Exception("Exception 1");
+        Exception exception2 = new Exception("Exception 2", exception1);
+        try {
+            // This is a hack to create a circular reference
+            java.lang.reflect.Field causeField = Throwable.class.getDeclaredField("cause");
+            causeField.setAccessible(true);
+            causeField.set(exception1, exception2);
+        } catch (Exception e) {
+            // If we can't create a circular reference, just use a normal chain
+            exception1.initCause(exception2);
+        }
+
+        // The method should handle circular references without infinite loops
+        assertFalse(invokeIsClientDisconnect(exception1));
+    }
+
+    /**
+     * Test that exceptions that should not be identified as client disconnects return false
+     */
+    @Test
+    public void testNonClientDisconnectExceptions() throws Exception {
+        // Test with a regular exception
+        assertFalse(invokeIsClientDisconnect(new Exception("Some random exception")));
+
+        // Test with null
+        assertFalse(invokeIsClientDisconnect(null));
+
+        // Test with an exception with a null message
+        Exception exceptionWithNullMessage = new Exception() {
+            @Override
+            public String getMessage() {
+                return null;
+            }
+        };
+        assertFalse(invokeIsClientDisconnect(exceptionWithNullMessage));
+    }
+
+    /**
+     * Test the getCookies method
+     */
+    @Test
+    public void testGetCookies() {
+        // Mock HttpServletRequest
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        // Test case: No cookies
+        Mockito.when(request.getCookies()).thenReturn(null);
+        assertTrue(JakartaServletWrapper.getCookies(request).isEmpty());
+
+        // Test case: With cookies
+        jakarta.servlet.http.Cookie cookie1 = new jakarta.servlet.http.Cookie("name1", "value1");
+        cookie1.setPath("/path1");
+        cookie1.setDomain("domain1");
+        cookie1.setSecure(true);
+        cookie1.setMaxAge(100);
+
+        jakarta.servlet.http.Cookie cookie2 = new jakarta.servlet.http.Cookie("name2", "value2");
+
+        Mockito.when(request.getCookies()).thenReturn(new jakarta.servlet.http.Cookie[]{cookie1, cookie2});
+
+        Map<String, play.mvc.Http.Cookie> cookies = JakartaServletWrapper.getCookies(request);
+        assertEquals(2, cookies.size());
+
+        // Verify first cookie
+        play.mvc.Http.Cookie playCookie1 = cookies.get("name1");
+        assertEquals("name1", playCookie1.name);
+        assertEquals("value1", playCookie1.value);
+        assertEquals("/path1", playCookie1.path);
+        assertEquals("domain1", playCookie1.domain);
+        assertTrue(playCookie1.secure);
+        assertEquals(Integer.valueOf(100), playCookie1.maxAge);
+
+        // Verify second cookie
+        play.mvc.Http.Cookie playCookie2 = cookies.get("name2");
+        assertEquals("name2", playCookie2.name);
+        assertEquals("value2", playCookie2.value);
+    }
+
+    /**
+     * Test the getHeaders method
+     */
+    @Test
+    public void testGetHeaders() {
+        // Mock HttpServletRequest
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        // Mock header names enumeration
+        Enumeration<String> headerNames = Collections.enumeration(Arrays.asList("Content-Type", "User-Agent"));
+        Mockito.when(request.getHeaderNames()).thenReturn(headerNames);
+
+        // Mock header values
+        Mockito.when(request.getHeaders("Content-Type")).thenReturn(
+                Collections.enumeration(Arrays.asList("text/html", "application/xhtml+xml")));
+        Mockito.when(request.getHeaders("User-Agent")).thenReturn(
+                Collections.enumeration(Arrays.asList("Mozilla/5.0")));
+
+        // Get headers
+        Map<String, play.mvc.Http.Header> headers = JakartaServletWrapper.getHeaders(request);
+
+        // Verify headers
+        assertEquals(2, headers.size());
+
+        // Verify Content-Type header
+        play.mvc.Http.Header contentTypeHeader = headers.get("content-type");
+        assertEquals("Content-Type", contentTypeHeader.name);
+        assertEquals(2, contentTypeHeader.values.size());
+        assertEquals("text/html", contentTypeHeader.values.get(0));
+        assertEquals("application/xhtml+xml", contentTypeHeader.values.get(1));
+
+        // Verify User-Agent header
+        play.mvc.Http.Header userAgentHeader = headers.get("user-agent");
+        assertEquals("User-Agent", userAgentHeader.name);
+        assertEquals(1, userAgentHeader.values.size());
+        assertEquals("Mozilla/5.0", userAgentHeader.values.get(0));
+    }
+
+    /**
+     * Test the copyStream method with null inputs
+     */
+    @Test
+    public void testCopyStreamWithNullInputs() throws Exception {
+        // Get access to the private copyStream method using reflection
+        Method copyStreamMethod = JakartaServletWrapper.class.getDeclaredMethod("copyStream",
+                HttpServletResponse.class, InputStream.class);
+        copyStreamMethod.setAccessible(true);
+
+        // Test with null response
+        copyStreamMethod.invoke(wrapper, null, new ByteArrayInputStream(new byte[0]));
+
+        // Test with null input stream
+        HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
+        copyStreamMethod.invoke(wrapper, mockResponse, null);
+
+        // Test with both null
+        copyStreamMethod.invoke(wrapper, null, null);
+
+        // No exceptions should be thrown
+    }
+
+    /**
+     * Test the copyStream method with valid inputs
+     */
+    @Test
+    public void testCopyStreamWithValidInputs() throws Exception {
+        // Get access to the private copyStream method using reflection
+        Method copyStreamMethod = JakartaServletWrapper.class.getDeclaredMethod("copyStream",
+                HttpServletResponse.class, InputStream.class);
+        copyStreamMethod.setAccessible(true);
+
+        // Create test data
+        byte[] testData = "Test data for copyStream".getBytes();
+        InputStream inputStream = new ByteArrayInputStream(testData);
+
+        // Mock HttpServletResponse and ServletOutputStream
+        HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
+        ServletOutputStream mockOutputStream = Mockito.mock(ServletOutputStream.class);
+        Mockito.when(mockResponse.getOutputStream()).thenReturn(mockOutputStream);
+
+        // Call the method
+        copyStreamMethod.invoke(wrapper, mockResponse, inputStream);
+
+        // Verify that getOutputStream was called
+        Mockito.verify(mockResponse).getOutputStream();
+    }
+
+    /**
+     * Test the copyStream method with client disconnect IOException
+     */
+    @Test
+    public void testCopyStreamWithClientDisconnectIOException() throws Exception {
+        // Get access to the private copyStream method using reflection
+        Method copyStreamMethod = JakartaServletWrapper.class.getDeclaredMethod("copyStream",
+                HttpServletResponse.class, InputStream.class);
+        copyStreamMethod.setAccessible(true);
+
+        // Create test data
+        byte[] testData = "Test data for copyStream".getBytes();
+        InputStream inputStream = new ByteArrayInputStream(testData);
+
+        // Mock HttpServletResponse and ServletOutputStream that throws a client disconnect IOException
+        HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
+        ServletOutputStream mockOutputStream = Mockito.mock(ServletOutputStream.class);
+        Mockito.when(mockResponse.getOutputStream()).thenReturn(mockOutputStream);
+
+        // Use a client disconnect message that will be recognized by isClientDisconnect
+        IOException clientDisconnectException = new IOException("Connection reset by peer");
+        Mockito.doThrow(clientDisconnectException).when(mockOutputStream).flush();
+
+        // Call the method - should not throw exception because it's caught internally
+        copyStreamMethod.invoke(wrapper, mockResponse, inputStream);
+    }
+
+    // Mock exception classes for testing class name patterns
+    private static class MockClientAbortException extends Exception {
+        // Class name contains "ClientAbortException"
+    }
+
+    private static class MockEofException extends Exception {
+        // Class name contains "EofException"
+    }
+
+    private static class MockConnectionClosedException extends Exception {
+        // Class name contains "ConnectionClosedException"
+    }
+}


### PR DESCRIPTION
Lower logging levels on servlets to trace for 404 responses and debug for client disconnects.

After moving to servlet environment, couple of cases of too verbose logging:
* 404 results to warn messages in the logs, this pr reduces those to trace, applications can implement higher levels if they want
* Client disconnect related exceptions bubble up and are logged as errors. Although these can sometimes be actual issues, most commonly this is a natural accurance and doesn't warrant an error to the log. The client disconnects are reported in different ways by different servlet containers (servlet spec doesn't cover it). The PR tries to detect these cases based on known exception class names and typical messages. If it detects one, it logs it on debug level and let's the request finish up normally.

The PR also adds a few tests for the JakartaServletWrapper.

Here is an example stacktrace of client abort exceptions on Tomcat:
```
play.exceptions.UnexpectedException: Unexpected Error
	at play.Invoker$Invocation.onException(Invoker.java:270)
	at play.Invoker$Invocation.run(Invoker.java:331)
	at play.server.JakartaServletWrapper$ServletInvocation.run(JakartaServletWrapper.java:549)
	at play.Invoker.invokeInThread(Invoker.java:77)
	at play.server.JakartaServletWrapper.service(JakartaServletWrapper.java:164)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:397)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:905)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: org.apache.catalina.connector.ClientAbortException: java.io.IOException: Broken pipe
	at org.apache.catalina.connector.OutputBuffer.realWriteBytes(OutputBuffer.java:346)
	at org.apache.catalina.connector.OutputBuffer.appendByteArray(OutputBuffer.java:751)
	at org.apache.catalina.connector.OutputBuffer.append(OutputBuffer.java:672)
	at org.apache.catalina.connector.OutputBuffer.writeBytes(OutputBuffer.java:381)
	at org.apache.catalina.connector.OutputBuffer.write(OutputBuffer.java:359)
	at org.apache.catalina.connector.CoyoteOutputStream.write(CoyoteOutputStream.java:103)
	at org.apache.catalina.connector.CoyoteOutputStream.write(CoyoteOutputStream.java:95)
	at play.server.JakartaServletWrapper.copyResponse(JakartaServletWrapper.java:493)
	at play.server.JakartaServletWrapper$ServletInvocation.execute(JakartaServletWrapper.java:559)
	at play.Invoker$Invocation.run(Invoker.java:322)
	... 25 more
Caused by: java.io.IOException: Broken pipe
	at java.base/sun.nio.ch.SocketDispatcher.write0(Native Method)
	at java.base/sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:62)
	at java.base/sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:137)
	at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:102)
	at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:58)
	at java.base/sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:542)
	at org.apache.tomcat.util.net.NioChannel.write(NioChannel.java:122)
	at org.apache.tomcat.util.net.NioEndpoint$NioSocketWrapper.doWrite(NioEndpoint.java:1378)
	at org.apache.tomcat.util.net.SocketWrapperBase.doWrite(SocketWrapperBase.java:764)
	at org.apache.tomcat.util.net.SocketWrapperBase.writeBlocking(SocketWrapperBase.java:589)
	at org.apache.tomcat.util.net.SocketWrapperBase.write(SocketWrapperBase.java:533)
	at org.apache.coyote.http11.Http11OutputBuffer$SocketOutputBuffer.doWrite(Http11OutputBuffer.java:548)
	at org.apache.coyote.http11.filters.IdentityOutputFilter.doWrite(IdentityOutputFilter.java:73)
	at org.apache.coyote.http11.Http11OutputBuffer.doWrite(Http11OutputBuffer.java:193)
	at org.apache.coyote.Response.doWrite(Response.java:631)
	at org.apache.catalina.connector.OutputBuffer.realWriteBytes(OutputBuffer.java:334)
```

