### PR TITLE
Include sameSite and httpOnly cookie attributes on servlets, align be…

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group 'com.nosto.play'
-version '1.8.0-nosto-GA-9'
+version '1.8.0-nosto-GA-10'
 
 java {
     withSourcesJar()


### PR DESCRIPTION
Include sameSite and httpOnly cookie attributes on servlets, align behaviors

We were not setting sameSite and httpOnly attributes correctly for cookies in JakartaServletWrapper, those are now added.

There are also few other changes to align the behavior of JakartaServletWrapper to be closer to PlayHandler:
* Send all cookies on error, don't use cookie.sendOnError attribute
* Include cookie.maxAge settings also on errors
* Support multiple headers with the same name in responses (addHeader vs setHeader)

There's also added tests for checking how cookies are written to the response