### PR TITLE
Use setHeader instead of addHeader to prevent duplicate headers

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group 'com.nosto.play'
-version '1.8.0-nosto-GA-10'
+version '1.8.0-nosto-GA-11'
 
 java {
     withSourcesJar()

--- a/framework/src/play/server/JakartaServletWrapper.java
+++ b/framework/src/play/server/JakartaServletWrapper.java
@@ -522,7 +522,7 @@ public class JakartaServletWrapper extends HttpServlet implements ServletContext
             Http.Header hd = entry.getValue();
             String key = entry.getKey();
             for (String value : hd.values) {
-                servletResponse.addHeader(key, value);
+                servletResponse.setHeader(key, value);
             }
         }
 


### PR DESCRIPTION
Use setHeader instead of addHeader to prevent duplicate headers