### PR TITLE
fix play classloading with bytecode cache

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group 'com.nosto.play'
-version '1.8.0-nosto-GA-13'
+version '1.8.0-nosto-GA-14'
 
 java {
     withSourcesJar()

--- a/framework/src/play/classloading/ApplicationClassloader.java
+++ b/framework/src/play/classloading/ApplicationClassloader.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -119,7 +120,9 @@ public class ApplicationClassloader extends ClassLoader {
                 Class<?> clazz = findLoadedClass(name);
                 if (clazz == null) {
                     if (name.endsWith("package-info")) {
-                        definePackage(getPackageName(name), null, null, null, null, null, null, null);
+                        if (getDefinedPackage(getPackageName(name)) == null) {
+                            definePackage(getPackageName(name), null, null, null, null, null, null, null);
+                        }
                     } else {
                         loadPackage(name);
                     }
@@ -151,14 +154,17 @@ public class ApplicationClassloader extends ClassLoader {
             }
 
             if (!applicationClass.isClass()) {
-                definePackage(applicationClass.getPackage(), null, null, null, null, null, null, null);
+                if (getDefinedPackage(applicationClass.getPackage()) == null) {
+                    definePackage(applicationClass.getPackage(), null, null, null, null, null, null, null);
+                }
             } else {
                 loadPackage(name);
             }
             if (bc != null) {
                 applicationClass.enhancedByteCode = bc;
-                applicationClass.javaClass = defineClass(applicationClass.name, applicationClass.enhancedByteCode, 0,
-                        applicationClass.enhancedByteCode.length, protectionDomain);
+                applicationClass.javaClass = Optional.<Class>ofNullable(findLoadedClass(applicationClass.name))
+                        .orElseGet(() -> defineClass(applicationClass.name, applicationClass.enhancedByteCode, 0,
+                                applicationClass.enhancedByteCode.length, protectionDomain));
                 resolveClass(applicationClass.javaClass);
                 if (!applicationClass.isClass()) {
                     applicationClass.javaPackage = applicationClass.javaClass.getPackage();


### PR DESCRIPTION
fixes issues like
```
Oops: IllegalArgumentException
Unexpected error : Unexpected Error, caused by exception IllegalArgumentException: controllers.admin.merchant.onsite

play.exceptions.UnexpectedException: Unexpected Error
        at play.Play.start(Play.java:597) ~[play-1.8.0-nosto-GA-13.jar:?]
        at play.server.Server.main(Server.java:169) [play-1.8.0-nosto-GA-13.jar:?]
Caused by: java.lang.IllegalArgumentException: controllers.admin.merchant.onsite
        at java.base/java.lang.ClassLoader.definePackage(ClassLoader.java:2239) ~[?:?]
        at play.classloading.ApplicationClassloader.loadApplicationClass(ApplicationClassloader.java:154) ~[play-1.8.0-nosto-GA-13.jar:?]
        at play.classloading.ApplicationClassloader.getAllClasses(ApplicationClassloader.java:447) ~[play-1.8.0-nosto-GA-13.jar:?]
        at play.Play.start(Play.java:551) ~[play-1.8.0-nosto-GA-13.jar:?]
```

and 
```
java.lang.LinkageError: loader play.classloading.ApplicationClassloader @f2bec99 attempted duplicate interface definition for controllers.admin.merchant.onsite.package-info. (controllers.admin.merchant.onsite.package-info is in unnamed module of loader play.classloading.ApplicationClassloader @f2bec99, parent loader 'app')
        at java.base/java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027) ~[?:?]
        at play.classloading.ApplicationClassloader.loadApplicationClass(ApplicationClassloader.java:164) ~[play-1.8.0-nosto-GA-13.jar:?]
        at play.classloading.ApplicationClassloader.getAllClasses(ApplicationClassloader.java:451) ~[play-1.8.0-nosto-GA-13.jar:?]
        at play.Play.start(Play.java:551) ~[play-1.8.0-nosto-GA-13.jar:?]
        at play.server.Server.main(Server.java:169) [play-1.8.0-nosto-GA-13.jar:?]
```

