### PR TITLE
Migrate workflows to 'infra-ci' runners group

### DIFF
--- a/.github/workflows/publish-to-codeartifact.yml
+++ b/.github/workflows/publish-to-codeartifact.yml
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on:
       group: infra-ci
-      labels: [self-hosted, linux, arm64, medium]
+      labels: [self-hosted, linux, medium]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish-to-codeartifact.yml
+++ b/.github/workflows/publish-to-codeartifact.yml
@@ -10,8 +10,8 @@ env:
 jobs:
   publish:
     runs-on:
-      group: Infrastructure
-      labels: [self-hosted, linux, arm64]
+      group: infra-ci
+      labels: [self-hosted, linux, arm64, medium]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Switch self-hosted runners from the legacy group to the new 'infra-ci' group, using explicit size labels based on workload requirements.

Jira issue - https://nostosolutions.atlassian.net/browse/IN-2929

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
